### PR TITLE
Add ModelPriceWatch (live hosted-API pricing) as a related resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ These LLMs (Large Language Models) are all licensed for commercial use (e.g., Ap
 - [TextSynth Server Benchmarks](https://bellard.org/ts_server/)
 - [Open LLM Leaderboard by Hugging Face](https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard)
 
+## Related resources
+
+- [ModelPriceWatch](https://modelpricewatch.com/) — live hosted-API pricing for open-weight (and proprietary) LLMs, auto-updated from provider pages; handy for the self-host-vs-rent-a-hosted-endpoint cost trade-off.
+
 ---
 
 ### What do the licences mean?


### PR DESCRIPTION
Hi Eugene — thanks for open-llms; the license + context-length table is a really useful reference for open-model selection.

Disclosure: I maintain [ModelPriceWatch](https://modelpricewatch.com/), an open pricing tracker for LLM APIs — flagging per self-promotion norms.

Once someone picks an open model here, a common next question is *"self-host, or rent a hosted endpoint, and at what token cost?"*. ModelPriceWatch tracks the live hosted-API price for open-weight (and proprietary) models, auto-updated from provider pages. I've added one do-follow text link under a new **Related resources** heading (kept out of the model tables) — no badge image, no tracking params. Totally fine to decline, reword, or move it.
